### PR TITLE
Add pre-jgitflow function

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -115,6 +115,7 @@ plugins/available/history.plugin.bash
 plugins/available/hub.plugin.bash
 plugins/available/java.plugin.bash
 plugins/available/jekyll.plugin.bash
+plugins/available/jgitflow.plugin.bash
 plugins/available/jump.plugin.bash
 plugins/available/latex.plugin.bash
 plugins/available/less-pretty-cat.plugin.bash

--- a/plugins/available/jgitflow.plugin.bash
+++ b/plugins/available/jgitflow.plugin.bash
@@ -1,47 +1,60 @@
+# shellcheck shell=bash
 cite about-plugin
 about-plugin 'Maven jgitflow build helpers'
 
-function hotfix-start {
-  about 'helper function for starting a new hotfix'
-  group 'jgitflow'
+function pre-jgitflow {
+	about 'helper function for execute before jgitflow'
+	group 'jgitflow'
+}
 
-  mvn jgitflow:hotfix-start ${JGITFLOW_MVN_ARGUMENTS}
+function test-pre-jgitflow {
+	about 'helper function for starting a new hotfix'
+	group 'jgitflow'
+
+	echo "Init pre-maven" && pre-jgitflow && echo "Finish pre-maven"
+}
+
+function hotfix-start {
+	about 'helper function for starting a new hotfix'
+	group 'jgitflow'
+
+  pre-jgitflow && mvn jgitflow:hotfix-start ${JGITFLOW_MVN_ARGUMENTS}
 }
 
 function hotfix-finish {
-  about 'helper function for finishing a hotfix'
-  group 'jgitflow'
+	about 'helper function for finishing a hotfix'
+	group 'jgitflow'
 
-  mvn jgitflow:hotfix-finish -Darguments="${JGITFLOW_MVN_ARGUMENTS}" && git push && git push origin master && git push --tags
+  pre-jgitflow && mvn jgitflow:hotfix-finish -Darguments="${JGITFLOW_MVN_ARGUMENTS}" && git push && git push origin master && git push --tags && mvn clean
 }
 
 function feature-start {
-  about 'helper function for starting a new feature'
-  group 'jgitflow'
+	about 'helper function for starting a new feature'
+	group 'jgitflow'
 
-  mvn jgitflow:feature-start ${JGITFLOW_MVN_ARGUMENTS}
+  pre-jgitflow && mvn jgitflow:feature-start ${JGITFLOW_MVN_ARGUMENTS}
 }
 
 function feature-finish {
-  about 'helper function for finishing a feature'
-  group 'jgitflow'
+	about 'helper function for finishing a feature'
+	group 'jgitflow'
 
-  mvn jgitflow:feature-finish ${JGITFLOW_MVN_ARGUMENTS}
-  echo -e '\033[32m----------------------------------------------------------------\033[0m'
-  echo -e '\033[32m===== REMEMBER TO CREATE A NEW RELEASE TO DEPLOY THIS FEATURE ====\033[0m'
-  echo -e '\033[32m----------------------------------------------------------------\033[0m'
+	pre-jgitflow && mvn jgitflow:feature-finish ${JGITFLOW_MVN_ARGUMENTS} && mvn clean
+	echo -e '\033[32m----------------------------------------------------------------\033[0m'
+	echo -e '\033[32m===== REMEMBER TO CREATE A NEW RELEASE TO DEPLOY THIS FEATURE ====\033[0m'
+	echo -e '\033[32m----------------------------------------------------------------\033[0m'
 }
 
 function release-start {
-  about 'helper function for starting a new release'
-  group 'jgitflow'
+	about 'helper function for starting a new release'
+	group 'jgitflow'
 
-  mvn jgitflow:release-start ${JGITFLOW_MVN_ARGUMENTS}
+	pre-jgitflow && mvn jgitflow:release-start ${JGITFLOW_MVN_ARGUMENTS}
 }
 
 function release-finish {
-  about 'helper function for finishing a release'
-  group 'jgitflow'
+	about 'helper function for finishing a release'
+	group 'jgitflow'
 
-  mvn jgitflow:release-finish -Darguments="${JGITFLOW_MVN_ARGUMENTS}" && git push && git push origin master && git push --tags
+	pre-jgitflow && mvn jgitflow:release-finish -Darguments="${JGITFLOW_MVN_ARGUMENTS}" && git push && git push origin master && git push --tags && mvn clean
 }


### PR DESCRIPTION
Add pre-jgitflow function

## Description
Prepare a function to be executed before any jgitflow command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have to check if I had access to my codeartifact repository before
any jgitflow command. With this improvement I can implement this function
on my ~/.bashrc file, and it would be executed before any jgitflow command.

```bash
function pre-jgitflow {
    source aws-auth-codeartifact
    return $(test -n "$CODEARTIFACT_AUTH_TOKEN")
}
```

## How Has This Been Tested?
I've been testing this process for a few months, but I don't know how to write
a unit test on this framework.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
